### PR TITLE
4 Streamlit URL Added

### DIFF
--- a/nyc-houses-price-estimator.url
+++ b/nyc-houses-price-estimator.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://nyc-houses-price-estimator.streamlit.app/


### PR DESCRIPTION
# 🌐 Add .url Shortcut to Open Streamlit App

## ✨ Context

To improve accessibility and ease of use for developers and stakeholders, this PR adds a simple `.url` file that directly opens the deployed NYC Housing Price Estimator app on Streamlit Cloud. This is especially useful when cloning the repo or browsing files locally, as it avoids the need to copy-paste the URL manually.

This PR solves issue #22 

This is the app link: https://nyc-houses-price-estimator.streamlit.app/

## 🧠 Rationale behind the change

- Simplifies access to the deployed Streamlit app.
- Acts as a clickable launcher for Windows users.

## Type of changes

- [x] 📝 Documentation
- [x] Other (Convenience file for external access)

## 🛠 What does this PR implement

- Adds the file: `nyc-houses-price-estimator.url`