### PR TITLE
4 project final details

### DIFF
--- a/nyc-houses-app.url
+++ b/nyc-houses-app.url
@@ -1,0 +1,3 @@
+[InternetShortcut]
+URL=https://nyc-houses-price-estimator-ind-batch.streamlit.app/
+IconFile=favicon.ico


### PR DESCRIPTION
# 🔗 Add Streamlit App Link as `.url` Shortcut

## ✨ Context

In the previous pull request #23, a fully functional Streamlit app was implemented, supporting both individual and batch prediction for NYC housing prices. This solved long-standing issues related to `xgboost` and `scikit-learn` version mismatches.

To improve discoverability and provide a quick access point to the app, we are now adding a `.url` file at the root of the repository pointing directly to the deployed app on Streamlit Cloud.

## 🧠 Rationale behind the change

Having a `.url` file is a convenient way to allow collaborators or users browsing the repo to **quickly launch the app** without digging through README files or PR descriptions.

It enhances user experience and reduces friction when demoing or testing the app.

## Type of changes

- [x] 📝 Documentation
- [x] 🔥 Improvements

## 🛠 What does this PR implement

- 📎 Adds a file: `NYC-House-Price-Estimator.url`
- This file contains a direct link to the 🔗 **Live app:** [NYC Housing Price Estimator (Individual + Batch)](https://nyc-houses-price-estimator-ind-batch.streamlit.app/)

## 🧪 How should this be tested?

- ✅ Double-click the `.url` file or open it in a browser to confirm it redirects correctly to the Streamlit app

